### PR TITLE
Design and Cleanup iteration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+*.code-workspace


### PR DESCRIPTION
Renamed Packet, which is an overloaded term, to MlspData
Added Send to MlspPackage
Added Borrow and AsRef to Mlsp
Removed "get" from Mlsp
Added Doc Tests and documentation
Added a multithreaded example