### PR TITLE
Refactor Mlsp to follow conventions and match naming of internals to Arc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,7 @@ mod tests {
         // Convince clippy that we need these values
         drop(c);
         drop(b);
+        drop(a);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,54 +4,51 @@ use core::sync::atomic;
 
 use std::borrow::Borrow;
 use std::boxed::Box;
-use std::sync::atomic::AtomicUsize;
 
+use std::ptr::NonNull;
 use std::sync::atomic::Ordering;
 
 /// The inner Arc-like portion of the Mlsp
 /// It is a wrapper tha bundles an atomic usize reference counter
 /// with an arbitrary value
-struct MlspData<T> {
-    atomic_count: AtomicUsize,
-    value: T
+struct MlspInner<T> {
+    atomic_count: atomic::AtomicUsize,
+    data: T
 }
 
-impl<T> MlspData<T> {
+impl<T> MlspInner<T> {
     /// Creates a new data bundle with an atomic counter with value 1
-    fn new(value: T) -> Self {
-        MlspData {
-            atomic_count: AtomicUsize::new(1),
-            value
+    fn new(data: T) -> Self {
+        MlspInner {
+            atomic_count: atomic::AtomicUsize::new(1),
+            data
         }
     }
 
-    /// Increment the atomic counter for a given MlspData pointer
-    fn increment(data: *const MlspData<T>) -> usize {
-        unsafe {
-            let old = (*data).atomic_count.fetch_add(1, Ordering::Release);
-            atomic::fence(Ordering::Acquire);
-            old
-        }
+    /// Increment the atomic counter for a given MlspInner pointer
+    /// 
+    /// # Safety
+    /// A caller to increment is obligated to later call decrement exactly once,
+    /// in order to ensure that the memory it contains is not leaked.
+    unsafe fn increment(&self) {
+        self.atomic_count.fetch_add(1, Ordering::Release);
     }
 
-    /// Decrement the atomic counter for a given MlspData pointer
-    fn decrement(data: *mut MlspData<T>) {
-        let counter = unsafe { &(*data).atomic_count };
+    /// Decrement the atomic counter for a given MlspInner pointer
+    /// 
+    /// # Safety
+    /// For each call to decrement there must have been exactly one
+    /// prior call to increment to prevent premature freeing.
+    unsafe fn decrement(&mut self) {
 
-        let old = counter.fetch_sub(1, Ordering::Release);
+        let old = self.atomic_count.fetch_sub(1, Ordering::Release);
         atomic::fence(Ordering::Acquire);
 
+        // If the value before decrementing was one,
+        // this caller is the last reference holder and the inner data must be dropped.
         if old == 1 {
-            unsafe {
-                // drop the wrapped value
-                ptr::drop_in_place(data);
-            }
+            ptr::drop_in_place(self);
         }
-    }
-
-    /// Get a reference to the inner value
-    fn get(&self) -> &T {
-        &self.value
     }
 }
 
@@ -63,7 +60,7 @@ impl<T> MlspData<T> {
 /// 
 /// Mlsp cannot be sent between threads.
 /// ```compile_fail
-/// use std::thread;
+/// # use std::thread;
 /// let a = mlsp::Mlsp::new(1u8);
 /// thread::spawn(move || {
 ///     let a2 = a;
@@ -73,7 +70,7 @@ impl<T> MlspData<T> {
 /// To send across thread boundaries, first package using the `package()` method
 /// and send the resulting package.
 /// ```
-/// use std::thread;
+/// # use std::thread;
 /// let a = mlsp::Mlsp::new(1u8);
 /// let a_pkg = a.package();
 /// thread::spawn(move || {
@@ -81,27 +78,33 @@ impl<T> MlspData<T> {
 /// });
 /// ```
 pub struct Mlsp<T> {
-    local_count: *mut Cell<usize>,
-    data_ptr: *mut MlspData<T>
+    local_count: NonNull<Cell<usize>>,
+    inner_ptr: NonNull<MlspInner<T>>
 }
 
 impl<T> Mlsp<T> {
     /// Creates a new Mlsp wrapping the given value with local and atomic
     /// counts both equal to one
-    pub fn new(value: T) -> Self {
+    pub fn new(data: T) -> Self {
+        let atomic_counter = Box::new(MlspInner::new(data));
+        let atomic_counter = Box::into_raw(atomic_counter);
+        let atomic_counter = NonNull::new(atomic_counter).unwrap();
+
         Mlsp {
-            local_count: Box::into_raw(Box::new(Cell::new(1))),
-            data_ptr: Box::into_raw(Box::new(MlspData::new(value)))
+            local_count: new_local_counter(),
+            inner_ptr: atomic_counter
         }
     }
 
     /// Create a Send-able package from the Mlsp
     /// This increments the atomic_count
     pub fn package(&self) -> MlspPackage<T> {
-        MlspData::increment(self.data_ptr);
+        unsafe {
+            self.inner_ptr.as_ref().increment();
+        }
 
         MlspPackage {
-            data_ptr: self.data_ptr
+            inner_ptr: self.inner_ptr
         }
     }
 }
@@ -109,7 +112,7 @@ impl<T> Mlsp<T> {
 impl<T> Borrow<T> for Mlsp<T> {
     fn borrow(&self) -> &T {
         unsafe {
-            (*self.data_ptr).get()
+            &self.inner_ptr.as_ref().data
         }
     }
 }
@@ -117,7 +120,7 @@ impl<T> Borrow<T> for Mlsp<T> {
 impl<T> AsRef<T> for Mlsp<T> {
     fn as_ref(&self) -> &T {
         unsafe {
-            (*self.data_ptr).get()
+            &self.inner_ptr.as_ref().data
         }
     }
 }
@@ -125,26 +128,29 @@ impl<T> AsRef<T> for Mlsp<T> {
 impl<T> Clone for Mlsp<T> {
     fn clone(&self) -> Self {
         unsafe {
-            let count = (*self.local_count).get();
+            let local_count = self.local_count.as_ref();
+
+            let count = local_count.get();
             let count = count + 1;
-            (*self.local_count).set(count);
+            local_count.set(count);
         }
 
         Mlsp {
             local_count: self.local_count,
-            data_ptr: self.data_ptr
+            inner_ptr: self.inner_ptr
         }
     }
 }
 
 impl<T> Drop for Mlsp<T> {
     fn drop(&mut self) {
-        // SAFETY: Performs unsafe operations on the counter pointer
+        // SAFETY: Requires that two `Mlsp`s for the same inner data must never exist in different threads 
         unsafe {
+            let local_count = self.local_count.as_mut();
             // Decrement the local_count
-            let count = (*self.local_count).get();
+            let count = local_count.get();
             let count = count - 1;
-            (*self.local_count).set(count);
+            local_count.set(count);
 
             // If the new value is greater than zero, there are still local references
             // and no further operations are needed.
@@ -155,20 +161,20 @@ impl<T> Drop for Mlsp<T> {
         // If the local_count was reduced to zero,
         // then this thread no longer has any references
 
-        // 1. Drop the local counter being used by this thread
-        // SAFETY: The only way to reach this line is by dropping all other references to self.local_count
+        // SAFETY: Requires that no other `Mlsp`s exist that reference the same local_count
         unsafe {
-            ptr::drop_in_place(self.local_count);
+            // Drop the local counter being used by this thread
+            ptr::drop_in_place(self.local_count.as_mut());
+            // Decrement the global pointer on the MlspInner and drop the inner data if necessary
+            self.inner_ptr.as_mut().decrement();
         }
-        // 2. Decrement the global pointer on the MlspData and drop if necessary
-        MlspData::decrement(self.data_ptr);
     }
 }
 
 /// A reference to the contents of an Mlsp
 /// that does not yet have a local counter and can be sent across threads.
 pub struct MlspPackage<T> {
-    data_ptr: *mut MlspData<T>
+    inner_ptr: NonNull<MlspInner<T>>
 }
 
 impl<T> MlspPackage<T> {
@@ -176,29 +182,46 @@ impl<T> MlspPackage<T> {
     /// be shared within this thread without atomic operations.
     pub fn unpackage(self) -> Mlsp<T> {
         Mlsp {
-            local_count: Box::into_raw(Box::new(Cell::new(1))),
-            data_ptr: self.data_ptr
+            local_count: new_local_counter(),
+            inner_ptr: self.inner_ptr
         }
     }
 }
 
 impl<T> Drop for MlspPackage<T> {
     fn drop(&mut self) {
-        // Decrement the global pointer on the MlspData and drop if necessary
-        MlspData::decrement(self.data_ptr);
+        unsafe {
+            // Decrement the global pointer on the MlspInner and drop if necessary
+            self.inner_ptr.as_mut().decrement();
+        }
     }
 }
 
-unsafe impl<T> Send for MlspPackage<T> {}
+unsafe impl<T: Sync + Send> Send for MlspPackage<T> {}
+unsafe impl<T: Sync + Send> Sync for MlspPackage<T> {}
 
 impl<T> Clone for MlspPackage<T> {
     fn clone(&self) -> Self {
-        MlspData::increment(self.data_ptr);
+        unsafe {
+            self.inner_ptr.as_ref().increment();
+        }
 
         MlspPackage {
-            data_ptr: self.data_ptr
+            inner_ptr: self.inner_ptr
         }
     }
+}
+
+
+fn new_local_counter() -> NonNull<Cell<usize>> {
+    // Allocate the counter as a boxed cell
+    let local_counter: Box<Cell<usize>> = Box::new(Cell::new(1));
+    // Create a mutable pointer to the cell and prevent dropping
+    let local_counter: *mut Cell<usize> = Box::into_raw(local_counter);
+    // Turn that pointer into a NonNull
+    let local_counter: NonNull<Cell<usize>> = NonNull::new(local_counter).unwrap();
+
+    local_counter
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,10 @@ mod tests {
 
         let e = c.package();
         let _e2 = e.unpackage();
+
+        // Convince clippy that we need these values
+        drop(c);
+        drop(b);
     }
 
     #[test]


### PR DESCRIPTION
* Renames `MlspData` to `MlspInner`
* Uses `NonNull` instead of base pointer type
* Uses `inner_ptr` for all `NonNull<MlspInner<T>>` in `Mlsp` and `MlspPackage`
* Made `MlspInner`s `increment` and `decrement` method-style and unsafe
* Formatted with `rustfmt`
* Related documentation changes